### PR TITLE
feat: Added support for "file" input types to open the camera/gallery picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ npx cap sync
 ## Usage
 
 This plugin uses a custom Javascript frontend, so each instance of the `WebviewOverlay` class will control a separate webview. The plugin requires an empty HTML element to determine the position and dimensions of the webview. This element is also used to display a screen capture of the webview if you need to have any app UI elements overlay the webview at any time. See the example project for implementation.
+
+## Development
+
+You can develop locally by using `pnpm link` in your app project to use a local version of the plugin.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,10 +19,11 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
+    namespace "com.clearxp.capacitor.webviewoverlay"
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 32
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.clearxp.capacitor.webviewoverlay">
+    >
 </manifest>

--- a/android/src/main/java/com/clearxp/capacitor/webviewoverlay/FileChooserWebChromeClient.java
+++ b/android/src/main/java/com/clearxp/capacitor/webviewoverlay/FileChooserWebChromeClient.java
@@ -1,0 +1,120 @@
+package com.clearxp.capacitor.webviewoverlay;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Environment;
+import android.provider.MediaStore;
+import android.util.Log;
+import android.webkit.ValueCallback;
+import android.webkit.WebChromeClient;
+import android.webkit.WebView;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * A custom WebChromeClient designed to handle file chooser requests from a WebView.
+ * This implementation allows for both capturing a new photo with the camera and
+ * selecting an existing file from the device's storage.
+ */
+public class FileChooserWebChromeClient extends WebChromeClient {
+
+    private static final String TAG = "CxpFileChooserClient";
+    public static final int INPUT_FILE_REQUEST_CODE = 1;
+
+    // NOTE: Using static fields is a simplification to bridge the Activity and the plugin.
+    // This is a fragile approach and can cause issues if multiple WebViews are used
+    // simultaneously or if the Android OS terminates and restores the app. A more
+    // robust solution would require a more complex architecture.
+    public static ValueCallback<Uri[]> mFilePathCallback;
+    public static String mCameraPhotoPath;
+
+    private Activity activity;
+
+    public FileChooserWebChromeClient(Activity activity) {
+        this.activity = activity;
+
+        Log.w(TAG, "Creating FileChooserWebChromeClient");
+    }
+
+    /**
+     * Creates a temporary image file to be used for storing the photo from the camera.
+     * @return The created File object.
+     * @throws IOException If the file could not be created.
+     */
+    private File createImageFile() throws IOException {
+        Log.w(TAG, "createImageFile");
+
+        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+        String imageFileName = "JPEG_" + timeStamp + "_";
+        // Use the app's private external files directory for better compatibility with Scoped Storage.
+        File storageDir = activity.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+        File imageFile = File.createTempFile(imageFileName, ".jpg", storageDir);
+        mCameraPhotoPath = imageFile.getAbsolutePath();
+        return imageFile;
+    }
+
+    /**
+     * This method is called by the WebView when a file input is clicked.
+     */
+    @Override
+    public boolean onShowFileChooser(WebView webView, ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams) {
+        Log.w(TAG, "onShowFileChooser");
+
+        // If there's already a callback, cancel it to avoid issues.[3]
+        if (mFilePathCallback != null) {
+            mFilePathCallback.onReceiveValue(null);
+            mFilePathCallback = null;
+        }
+
+        mFilePathCallback = filePathCallback;
+
+        // Create an intent to launch the camera
+        Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        if (takePictureIntent.resolveActivity(activity.getPackageManager())!= null) {
+            Log.w(TAG, "onShowFileChooser - take picture");
+
+            File photoFile = null;
+            try {
+                photoFile = createImageFile();
+            } catch (IOException ex) {
+                Log.e(TAG, "Unable to create Image File", ex);
+            }
+
+            if (photoFile != null) {
+                Uri photoURI = Uri.fromFile(photoFile);
+                takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI);
+            } else {
+                takePictureIntent = null;
+            }
+        }
+
+        // Create an intent to open the file picker
+        Intent contentSelectionIntent = new Intent(Intent.ACTION_GET_CONTENT);
+        contentSelectionIntent.addCategory(Intent.CATEGORY_OPENABLE);
+        contentSelectionIntent.setType("*/*"); // You can restrict this to "image/*" etc.
+
+        // Create an array of intents to include the camera option
+        Intent[] intentArray;
+        if (takePictureIntent != null) {
+            intentArray = new Intent[]{ takePictureIntent };
+        } else {
+            intentArray = new Intent[]{};
+        }
+
+        Log.w(TAG, "onShowFileChooser - choose intent");
+
+        // The main chooser intent that wraps the file picker
+        Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
+        chooserIntent.putExtra(Intent.EXTRA_INTENT, contentSelectionIntent);
+        chooserIntent.putExtra(Intent.EXTRA_TITLE, "Choose Action");
+        // Add the camera intent as an extra option in the chooser
+        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intentArray);
+
+        activity.startActivityForResult(chooserIntent, INPUT_FILE_REQUEST_CODE);
+        return true; // Return true to indicate we've handled the event.[4]
+    }
+}

--- a/android/src/main/java/com/clearxp/capacitor/webviewoverlay/FileChooserWebChromeClient.java
+++ b/android/src/main/java/com/clearxp/capacitor/webviewoverlay/FileChooserWebChromeClient.java
@@ -41,7 +41,7 @@ public class FileChooserWebChromeClient extends WebChromeClient {
     public FileChooserWebChromeClient(Activity activity) {
         this.activity = activity;
 
-        Log.w(TAG, "Creating FileChooserWebChromeClient");
+        Log.d(TAG, "Creating FileChooserWebChromeClient");
     }
 
     /**
@@ -50,7 +50,7 @@ public class FileChooserWebChromeClient extends WebChromeClient {
      * @throws IOException If the file could not be created.
      */
     private File createImageFile() throws IOException {
-        Log.w(TAG, "createImageFile");
+        Log.d(TAG, "createImageFile");
 
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "JPEG_" + timeStamp + "_";
@@ -71,7 +71,7 @@ public class FileChooserWebChromeClient extends WebChromeClient {
      */
     @Override
     public boolean onShowFileChooser(WebView webView, ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams) {
-        Log.w(TAG, "onShowFileChooser");
+        Log.d(TAG, "onShowFileChooser");
 
         // If there's already a callback, cancel it to avoid issues.[3]
         if (mFilePathCallback != null) {
@@ -84,7 +84,7 @@ public class FileChooserWebChromeClient extends WebChromeClient {
         // Create an intent to launch the camera
         Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
         if (takePictureIntent.resolveActivity(activity.getPackageManager())!= null) {
-            Log.w(TAG, "onShowFileChooser - take picture");
+            Log.d(TAG, "onShowFileChooser - take picture");
 
             File photoFile = null;
             try {
@@ -128,7 +128,7 @@ public class FileChooserWebChromeClient extends WebChromeClient {
             intentArray = new Intent[]{};
         }
 
-        Log.w(TAG, "onShowFileChooser - choose intent");
+        Log.d(TAG, "onShowFileChooser - choose intent");
 
         // The main chooser intent that wraps the file picker
         Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);

--- a/android/src/main/java/com/clearxp/capacitor/webviewoverlay/FileChooserWebChromeClient.java
+++ b/android/src/main/java/com/clearxp/capacitor/webviewoverlay/FileChooserWebChromeClient.java
@@ -73,7 +73,7 @@ public class FileChooserWebChromeClient extends WebChromeClient {
     public boolean onShowFileChooser(WebView webView, ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams) {
         Log.d(TAG, "onShowFileChooser");
 
-        // If there's already a callback, cancel it to avoid issues.[3]
+        // If there's already a callback, cancel it to avoid issues.
         if (mFilePathCallback != null) {
             mFilePathCallback.onReceiveValue(null);
             mFilePathCallback = null;
@@ -138,6 +138,6 @@ public class FileChooserWebChromeClient extends WebChromeClient {
         chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intentArray);
 
         activity.startActivityForResult(chooserIntent, INPUT_FILE_REQUEST_CODE);
-        return true; // Return true to indicate we've handled the event.[4]
+        return true; // Return true to indicate we've handled the event.
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@clear/capacitor-webview-overlay",
-    "version": "3.0.2",
+    "version": "3.1.0",
     "description": "Webview Overlay",
     "main": "dist/plugin.cjs.js",
     "module": "dist/esm/index.js",


### PR DESCRIPTION
<!--
     A brief template to writing a concise pull request. Think of this as a checklist to remind us of the key information we need to include for other engineers. Where you feel you need to add or remove information you are free to do so - always remember to *be pragmatic*.
     
     P.S. If you think this is template is missing something, suggest an edit.
-->

## This is a (check all applicable)

- [X] Feature (`feat`)
- [ ] Bug Fix (`fix`)
- [ ] Chore (`chore`)
- [ ] Refactor (`refactor`)
- [ ] Optimisation (`perf`)
- [ ] Other

## This is documented in

- [X] Lucid: https://lucid.clearxp.life/article/https%3A%2F%2Flucid.clearxp.life%2Fws%2Fclear%2Factivities%2FoDLMRyYKE2iDZFmlRwiTN#2-file-input%20support%20on%20android
- [ ] GitBook
- [ ] The code
- [ ] Nowhere, and this is why: `TODO`

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: Legacy code

## Description

<!--
A brief overview of the pull request.
-->
This adds support for the `<input type="file">` element within the WebView's HTML content.

Created `FileChooserWebChromeClient.java` with logic for handling file selection, including:
- Overriding `onShowFileChooser`
- Instance variables to store the `ValueCallback<Uri>` from the WebView and a `String` to hold the file path for photos taken with the camera.
- Logic within `onShowFileChooser` to create a chooser `Intent`. This intent should combine `MediaStore.ACTION_IMAGE_CAPTURE` and `Intent.ACTION_GET_CONTENT` to give the user the choice between using the camera and selecting from the file gallery.  
- A helper method, such as `createImageFile()`, to generate a temporary file where the camera app can save the captured image.

